### PR TITLE
added condition in get_packages() to skip blank lines in the name file

### DIFF
--- a/mfsetup/utils.py
+++ b/mfsetup/utils.py
@@ -127,6 +127,7 @@ def get_packages(namefile):
         read = True
         for line in src:
             if line.startswith('#') or \
+                    len(line.strip()) < 1 or \
                     line.lower().startswith('data') or \
                     line.lower().strip().startswith('list'):
                 continue


### PR DESCRIPTION
mfsetup was throwing an empty list error because of a blank line in 
a name file.  I added a condition to skip blank lines in get_packages().

