### PR TITLE
minor fixes for mf6 model setup

### DIFF
--- a/mfsetup/mf6model.py
+++ b/mfsetup/mf6model.py
@@ -479,7 +479,8 @@ class MF6model(MFsetupMixin, mf6.ModflowGwf):
         print("finished in {:.2f}s\n".format(time.time() - t0))
         return dis
 
-    def setup_tdis(self):
+    #def setup_tdis(self):
+    def setup_tdis(self, **kwargs):
         """
         Sets up the TDIS package.
         """

--- a/mfsetup/sourcedata.py
+++ b/mfsetup/sourcedata.py
@@ -1212,6 +1212,8 @@ def setup_array(model, package, var, data=None,
     # data specified as source_data
     elif cfg is not None and var in cfg:
 
+        from_model = False
+
         # get the source data block
         # determine if source data is from another model
         source_data_input = cfg.get(var)


### PR DESCRIPTION
Missing **kwargs argument in `setup_tdis()`  caused crash when called from [package_setup](https://github.com/DOI-USGS/modflow-setup/blob/4bfd847ad05dd8efb8d43162d3c96ae91065f0a7/mfsetup/mfmodel.py#L1747).

Boolean var [from_model](https://github.com/DOI-USGS/modflow-setup/blob/4bfd847ad05dd8efb8d43162d3c96ae91065f0a7/mfsetup/sourcedata.py#L1228) not initialized when data taken from a file.