### PR TITLE
fix(mf6model.write_input): handle cases of single model or multi-mode…

### DIFF
--- a/ci/test_environment.yaml
+++ b/ci/test_environment.yaml
@@ -9,7 +9,7 @@ dependencies:
 - ipykernel
 - matplotlib
 - pyyaml
-- numpy
+- numpy<2.1
 - scipy
 - xarray
 - netcdf4

--- a/mfsetup/mf6model.py
+++ b/mfsetup/mf6model.py
@@ -243,7 +243,6 @@ class MF6model(MFsetupMixin, mf6.ModflowGwf):
         # re-write the input files
         # todo: integrate this better with setup_dis
         # to reduce the number of times the arrays need to be remade
-
         self._setup_array('dis', 'botm',
                         data={i: arr for i, arr in enumerate(botm)},
                         datatype='array3d', resample_method='linear',
@@ -981,7 +980,14 @@ class MF6model(MFsetupMixin, mf6.ModflowGwf):
                     remove_inactive_bcs(package_instance,
                                         external_files=external_files)
             if hasattr(model, 'obs'):
-                for obs_package_instance in model.obs:
+                # handle case of single obs package, in which case model.obs
+                # will be a ModflowUtlobs package instance
+                try:
+                    len(model.obs)
+                    obs_packages = model.obs
+                except:
+                    obs_packages = [model.obs]
+                for obs_package_instance in obs_packages:
                     remove_inactive_obs(obs_package_instance)
 
             # write the model with flopy


### PR DESCRIPTION
…l LGR simulation by working with the simulation-level model dictionary to implement model write functionality that is not included in the simulation-level write_simulation(). Previously, BCs were presumably not getting removed from inactive cells, auxillary header information such as modflow-setup and model version were not getting written to child model package files, and child model SFR packagedata was not getting written to an external file.