### PR TITLE
hotfix(tdis.py::aggregate_xarray_to_stress_period): copy period_stat input

### DIFF
--- a/mfsetup/tdis.py
+++ b/mfsetup/tdis.py
@@ -770,6 +770,7 @@ def aggregate_xarray_to_stress_period(data, datetime_coords_name='time',
                                       start_datetime=None, end_datetime=None,
                                       period_stat='mean'):
 
+    period_stat = copy.copy(period_stat)
     if isinstance(start_datetime, pd.Timestamp):
         start_datetime = start_datetime.strftime('%Y-%m-%d')
     if isinstance(end_datetime, pd.Timestamp):

--- a/mfsetup/tests/test_mf6_shellmound.py
+++ b/mfsetup/tests/test_mf6_shellmound.py
@@ -579,8 +579,8 @@ def test_rch_setup(shellmound_model_with_dis):
 
     #assert np.allclose(values, m.rch.recharge.array[0, 0])
     # test period 1 avg. for those times
-    start = m.cfg['rch']['source_data']['recharge']['period_stats'][1][0]
-    end = m.cfg['rch']['source_data']['recharge']['period_stats'][1][1]
+    start = m.cfg['rch']['source_data']['recharge']['period_stats'][1][1]
+    end = m.cfg['rch']['source_data']['recharge']['period_stats'][1][2]
     values1 = get_period_values(start, end)
     assert testing.rpd(values1.mean(), m.rch.recharge.array[1, 0].mean()) < 0.01
 


### PR DESCRIPTION
so that it doesn't get modified by multiple function calls; this affected instances where list input to a period_stats sub-block was supplied for one period in an multi-stress period model (causing it to be repeated), or to multiple periods.