### PR TITLE
fix(MF6model.write_input): don't check for mover package if mover is …

### DIFF
--- a/mfsetup/mf6model.py
+++ b/mfsetup/mf6model.py
@@ -1028,9 +1028,6 @@ class MF6model(MFsetupMixin, mf6.ModflowGwf):
             if 'SFR' in ' '.join(model.get_package_list()):
                 options = []
                 for k, b in model.cfg['sfr']['options'].items():
-                    if k == 'mover':
-                        if 'mvr' not in model.simulation.package_key_dict:
-                            continue
                     options.append(k)
                 if 'save_flows' in options:
                     budget_fileout = '{}.{}'.format(model_name,

--- a/mfsetup/tests/test_mover.py
+++ b/mfsetup/tests/test_mover.py
@@ -1,0 +1,38 @@
+from copy import deepcopy
+
+import pytest
+from shapely.geometry import Point
+
+from mfsetup import MF6model
+from mfsetup.mover import get_connections
+
+
+@pytest.mark.parametrize('from_features,to_features,expected_n_connections',
+                         (([Point(1, 1)], [Point(1, 1)], 1),
+                          ([Point(1, 1)], [Point(2, 2)], 0)
+                          )
+                         )
+def test_get_connections(from_features, to_features, expected_n_connections):
+    """Simple test for the get_connections function,
+    which is not currently in the code but may be useful
+    for implementing a proximity-based routing feature in
+    SFRmaker (for flowlines that only include routing information).
+    """
+    results = get_connections(from_features, to_features,
+                              distance_threshold=1)
+    assert len(results) == expected_n_connections
+
+
+def test_sfr_mover(pleasant_mf6_cfg, project_root_path, tmpdir):
+    """Test that 'mover' gets added to the SFR Package input file options block
+    when it is specified in the configuration file options block."""
+    cfg = deepcopy(pleasant_mf6_cfg)
+    cfg['sfr']['options']['mover'] = True
+    m = MF6model(cfg=cfg)
+    m.setup_dis()
+    m.setup_tdis()
+    m.setup_sfr()
+    m.write_input()
+    with open(m.sfr.filename) as src:
+        text = src.read()
+        assert 'mover' in text


### PR DESCRIPTION
…in the SFR options block (not clear that this check is needed). Previously was not passing mover option if simulation-level mover package not found.