### PR TITLE
fix(mover.py::get_sfr_package_connections): circular SFR Mover connections edge case

### DIFF
--- a/mfsetup/tests/test_lgr.py
+++ b/mfsetup/tests/test_lgr.py
@@ -328,6 +328,14 @@ def test_mover_get_sfr_package_connections(pleasant_lgr_setup_from_yaml):
     # {inset_reach: parent_reach, ...}
     assert to_parent == {29: 13, 41: 1}
 
+    # test for no circular connections when two outlets are connected
+    # and distance_threshold is large
+    parent_reach_data.loc[parent_reach_data['rno'] == list(to_parent.values())[0], 'outreach'] = 0
+    to_inset, to_parent = get_sfr_package_connections(
+    gwfgwf_exchangedata,
+    parent_reach_data, inset_reach_data, distance_threshold=1e4)
+    assert not any(to_inset)
+
 
 def test_meandering_sfr_connections(shellmound_cfg, project_root_path, tmpdir):
     """Test for SFR routing continuity in LGR cases

--- a/mfsetup/tests/test_mover.py
+++ b/mfsetup/tests/test_mover.py
@@ -1,3 +1,7 @@
+"""Test functions in the mover.py module. See test_lgr.py for
+a test of the test_mover_get_sfr_package_connections function.
+
+"""
 from copy import deepcopy
 
 import pytest


### PR DESCRIPTION
When two outlets are connected across a LGR model interface and the connection threshold distance is large, a circular or double connection going both ways between the two models may result, which can prevent the Mover Package from converging in the simulation. This issue was fixed by adding a check for double connections, and then only retaining the connection with the smallest distance (which should always be correct if the flowline input to the SFR Package was digitized correctly).