### PR TITLE
remove old import statement, fix incomplete fill_cells_vertically() return statement

### DIFF
--- a/mfsetup/discretization.py
+++ b/mfsetup/discretization.py
@@ -256,11 +256,6 @@ def fill_cells_vertically(top, botm):
     -------
     top, botm : filled top and botm arrays
     """
-    # check for nans in "top" array, if any nans exist, raise an error
-    # nans in top array could have unexpected effects
-    if np.isnan(top).any():
-        raise ValueError("Error: The top array contains NaN values. Ensure these are defined to prevent unintended results.")
-
     thickness = get_layer_thicknesses(top, botm)
     assert np.all(np.isnan(thickness[np.isnan(thickness)]))
     thickness[np.isnan(thickness)] = 0

--- a/mfsetup/discretization.py
+++ b/mfsetup/discretization.py
@@ -256,6 +256,11 @@ def fill_cells_vertically(top, botm):
     -------
     top, botm : filled top and botm arrays
     """
+    # check for nans in "top" array, if any nans exist, raise an error
+    # nans in top array could have unexpected effects
+    if np.isnan(top).any():
+        raise ValueError("Error: The top array contains NaN values. Ensure these are defined to prevent unintended results.")
+
     thickness = get_layer_thicknesses(top, botm)
     assert np.all(np.isnan(thickness[np.isnan(thickness)]))
     thickness[np.isnan(thickness)] = 0
@@ -271,7 +276,7 @@ def fill_cells_vertically(top, botm):
     filled += np.nanmin(all_surfaces, axis=0)  # botm[-1]
     # append the model bottom elevations
     filled = np.append(filled, [np.nanmin(all_surfaces, axis=0)], axis=0)
-    return filled[1:].copy()
+    return top, filled[1:].copy()
 
 
 def fix_model_layer_conflicts(top_array, botm_array,

--- a/mfsetup/discretization.py
+++ b/mfsetup/discretization.py
@@ -249,12 +249,12 @@ def fill_cells_vertically(top, botm):
 
     Parameters
     ----------
-    top : 2D numpy array; model top elevations
+    top : 2D (nrow, ncol) array; model top elevations
     botm : 3D (nlay, nrow, ncol) array; model bottom elevations
 
     Returns
     -------
-    top, botm : filled top and botm arrays
+    botm : filled botm array
     """
     thickness = get_layer_thicknesses(top, botm)
     assert np.all(np.isnan(thickness[np.isnan(thickness)]))
@@ -271,7 +271,7 @@ def fill_cells_vertically(top, botm):
     filled += np.nanmin(all_surfaces, axis=0)  # botm[-1]
     # append the model bottom elevations
     filled = np.append(filled, [np.nanmin(all_surfaces, axis=0)], axis=0)
-    return top, filled[1:].copy()
+    return filled[1:].copy()
 
 
 def fix_model_layer_conflicts(top_array, botm_array,

--- a/mfsetup/equality.py
+++ b/mfsetup/equality.py
@@ -8,7 +8,6 @@ fm = flopy.modflow
 mf6 = flopy.mf6
 from flopy.datbase import DataInterface, DataType
 from flopy.mbase import ModelInterface
-from flopy.utils import TemporalReference
 
 
 def get_package_list(model):
@@ -81,8 +80,6 @@ def package_eq(pk1, pk2):
                     # TODO: this may return False if there are nans
                     elif not np.allclose(v.array, v2.array):
                         return False
-        elif isinstance(v, TemporalReference):
-            pass
         elif v != v2:
             return False
     return True

--- a/mfsetup/fileio.py
+++ b/mfsetup/fileio.py
@@ -647,25 +647,6 @@ def flopy_mf2005_load(m, load_only=None, forgive=False, check=False):
     m.setup_grid()  # reset model grid now that DIS package is loaded
     assert m.pop_key_list.pop() == dis_key
     ext_unit_dict.pop(dis_key)  #.filehandle.close()
-    #start_datetime = attribs.pop("start_datetime", "01-01-1970")
-    #itmuni = attribs.pop("itmuni", 4)
-    #ref_source = attribs.pop("source", "defaults")
-    # if m.structured:
-    #    # get model units from usgs.model.reference, if provided
-    #    if ref_source == 'usgs.model.reference':
-    #        pass
-    #    # otherwise get them from the DIS file
-    #    else:
-    #        itmuni = dis.itmuni
-    #        ref_attributes['lenuni'] = dis.lenuni
-    #    sr = SpatialReference(delr=m.dis.delr.array, delc=ml.dis.delc.array,
-    #                          **ref_attributes)
-    # else:
-    #    sr = None
-    #
-    #dis.sr = m.sr
-    #dis.tr = TemporalReference(itmuni=itmuni, start_datetime=start_datetime)
-    #dis.start_datetime = start_datetime
 
     if load_only is None:
         # load all packages/files

--- a/mfsetup/fileio.py
+++ b/mfsetup/fileio.py
@@ -25,7 +25,7 @@ from flopy.mf6.mfbase import (
 )
 from flopy.mf6.modflow import mfims, mftdis
 from flopy.modflow.mf import ModflowGlobal
-from flopy.utils import TemporalReference, mfreadnam
+from flopy.utils import mfreadnam
 
 import mfsetup
 from mfsetup.grid import MFsetupGrid


### PR DESCRIPTION
Removed unused flopy TemporalReference import from fileio.py. TemporalReference does not exist in flopy v3.9.2. Additionally, fixed return statement for fill_cells_vertically() function so that it also returns the top array, matching the docstring. Also added a check for the exception case where there are nan(s) in the top array, which may yield unintended results.