### PR TITLE
Add test_releases.yml workflow to test different install options for latest release (github; pypi; conda)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,12 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: ['3.12', '3.11', '3.10']  # ['3.8', '3.x']
+        python-version: [3.13, 3.12, 3.11]  # ['3.8', '3.x']
         exclude:
           # tests with ubuntu-latest, python latest
           # are executed by build_docs.yaml
           - os: ubuntu-latest
-            python-version: 3.12
+            python-version: 3.13
 
     steps:
     - name: Checkout source
@@ -78,22 +78,16 @@ jobs:
         cp -r bin/$d/. "$HOME/.local/bin/"
         echo "$HOME/.local/bin" >> $GITHUB_PATH
         echo $GITHUB_PATH
-    - name: Test install from git
+    # on Windows, test against last Flopy release
+    - name: Install latest PyPI flopy
       shell: bash -l {0}
-      run: |
-        pip install git+https://github.com/aleaf/modflow-setup@develop
-        cd ..
-        python -c "import mfsetup"
-        cd modflow-setup
+      if: contains(matrix.os, 'windows')
+      run: pip install flopy --force-reinstall
     - name: Install Modflow-setup and ipykernel
       shell: bash -l {0}
       run: |
         pip install -e .
         python -m ipykernel install --user --name mfsetup_ci --display-name "mfsetup_ci"
-    - name: Install latest PyPI flopy
-      shell: bash -l {0}
-      if: ${{ matrix.python-version == 3.11}}
-      run: pip install flopy --force-reinstall
     - name: Conda list
       shell: bash -l {0}
       run: |

--- a/.github/workflows/test_releases.yml
+++ b/.github/workflows/test_releases.yml
@@ -1,0 +1,60 @@
+# Test that latest published versions can be installed & imported
+
+name: Latest Release
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # run every Monday at 9 AM UTC (3 am PST)
+  push:
+  #pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Test Latest Releases
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Fetch all Git tags
+      run: git fetch --prune --unshallow --tags
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+    - name: Setup Micromamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: ci/test_environment.yaml
+        cache-environment: false
+        cache-downloads: false
+        # persist on the same day.
+        # cache-environment-key: environment-${{ steps.date.outputs.date }}
+        # cache-downloads-key: downloads-${{ steps.date.outputs.date }}
+        create-args: >-
+          python=${{ matrix.python-version }}
+        init-shell: >-
+          bash
+    - name: Conda info
+      shell: bash -l {0}
+      run: micromamba info
+    - name: Test install from github
+      shell: bash -l {0}
+      run: |
+        pip install git+https://github.com/aleaf/modflow-setup@develop
+        pytest mfsetup/tests/test_import.py
+    - run: pip uninstall modflow-setup -y
+    - name: Test install from pypi
+      shell: bash -l {0}
+      run: |
+        pip install modflow-setup
+        pytest mfsetup/tests/test_import.py
+    - run: pip uninstall modflow-setup -y
+    - name: Test install from conda
+      shell: bash -l {0}
+      run: |
+        micromamba install modflow-setup
+        pytest mfsetup/tests/test_import.py
+    - run: micromamba remove modflow-setup --force

--- a/ci/test_environment.yaml
+++ b/ci/test_environment.yaml
@@ -9,7 +9,7 @@ dependencies:
 - ipykernel
 - matplotlib
 - pyyaml
-- numpy<2.1
+- numpy
 - scipy
 - xarray
 - netcdf4

--- a/mfsetup/tests/test_import.py
+++ b/mfsetup/tests/test_import.py
@@ -1,0 +1,11 @@
+import os
+import subprocess as sp
+from pathlib import Path
+
+
+def test_import():
+    """Test that Modflow-setup is installed, and can be imported
+    (from another location besides the repo top-level, which contains the
+    'mfsetup' folder)."""
+    os.system("python -c 'import mfsetup'")
+    results = sp.check_call(["python", "-c", "import mfsetup"], cwd=Path('..'))


### PR DESCRIPTION
- in test.yaml: test against latest flopy on all windows runs.
- bump supported python versions to 3.13-3.11