### PR TITLE
Fix external file paths dependency on OS #106

### DIFF
--- a/mfsetup/fileio.py
+++ b/mfsetup/fileio.py
@@ -483,13 +483,12 @@ def setup_external_filepaths(model, package, variable_name,
 
     model.get_package(package)
     # intermediate data
-    filename_format = os.path.split(filename_format)[-1]
-    if not relative_external_paths:
-        intermediate_files = [os.path.normpath(os.path.join(model.tmpdir,
-                              filename_format).format(i)) for i in file_numbers]
-    else:
-        intermediate_files = [os.path.join(model.tmpdir,
-                              filename_format).format(i) for i in file_numbers]
+    filename_format = Path(filename_format).name #os.path.split(filename_format)[-1]
+    # if not relative_external_paths:
+    intermediate_files = [(model.tmpdir / filename_format.format(i)).as_posix() for i in file_numbers]
+    # else:
+        # intermediate_files = [os.path.join(model.tmpdir,
+        #                       filename_format).format(i) for i in file_numbers]
 
     if variable_name in transient2D_variables or variable_name in transient_tabular_variables:
         model.cfg['intermediate_data'][variable_name] = {per: f for per, f in
@@ -503,14 +502,13 @@ def setup_external_filepaths(model, package, variable_name,
 
     # external array(s) read by MODFLOW
     # (set to reflect expected locations where flopy will save them)
-    if not relative_external_paths:
-        external_files = [os.path.normpath(os.path.join(model.model_ws,
-                                       model.external_path,
-                                       filename_format.format(i))) for i in file_numbers]
-    else:
-        external_files = [os.path.join(model.model_ws,
-                                       model.external_path,
-                                       filename_format.format(i)) for i in file_numbers]
+    # if not relative_external_paths:
+    external_files = [(model.model_ws / model.external_path / filename_format.format(i)).as_posix()
+                       for i in file_numbers]
+    # else:
+    #     external_files = [os.path.join(model.model_ws,
+    #                                    model.external_path,
+    #                                    filename_format.format(i)) for i in file_numbers]
 
     if variable_name in transient2D_variables or variable_name in transient_tabular_variables:
         model.cfg['external_files'][variable_name] = {per: f for per, f in

--- a/mfsetup/mfmodel.py
+++ b/mfsetup/mfmodel.py
@@ -422,7 +422,7 @@ class MFsetupMixin():
             ext_path = os.path.relpath(abspath)
         else:
             ext_path = os.path.normpath(abspath)
-        return ext_path
+        return Path(ext_path)
 
     @external_path.setter
     def external_path(self, x):

--- a/mfsetup/tests/test_mf6_shellmound.py
+++ b/mfsetup/tests/test_mf6_shellmound.py
@@ -250,19 +250,15 @@ def test_package_external_file_path_setup(shellmound_model_with_grid,
                     assert not os.path.isabs(path)
 
     assert m.cfg['intermediate_data']['top'] == \
-           [os.path.normpath(os.path.join(m.tmpdir, os.path.split(top_filename)[-1]))]
+           [(m.tmpdir / Path(top_filename).name).as_posix()]
     assert m.cfg['intermediate_data']['botm'] == \
-           [os.path.normpath(os.path.join(m.tmpdir, botm_file_fmt).format(i))
-                                  for i in range(m.nlay)]
+           [(m.tmpdir / botm_file_fmt.format(i)).as_posix() for i in range(m.nlay)]
     if not relative_external_paths:
         assert m.cfg['dis']['griddata']['top'] == \
-               [{'filename': os.path.normpath(os.path.join(m.model_ws,
-                            m.external_path,
-                            os.path.split(top_filename)[-1]))}]
+               [{'filename': (m.model_ws / m.external_path / Path(top_filename).name).as_posix()}]
         assert m.cfg['dis']['griddata']['botm'] == \
-               [{'filename': os.path.normpath(os.path.join(m.model_ws,
-                             m.external_path,
-                             botm_file_fmt.format(i)))} for i in range(m.nlay)]
+               [{'filename': (m.model_ws / m.external_path / botm_file_fmt.format(i)).as_posix()}
+                for i in range(m.nlay)]
 
 
 def test_set_lakarr(shellmound_model_with_dis):


### PR DESCRIPTION
- fixes #106 by refactoring to use `pathlib.Path.as_posix()` 
- required an update to `test_mf6_shellmound`
- small change in mfmodel to ensure Path object
